### PR TITLE
Bg linux line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /docker/scripts/app_list/app_list.dev.csv
 /docker/scripts/app_list/app_list.prod.csv
 /docker/scripts/app_list/app_list.qa.csv
+
+/docker/scripts/logs/*
+!/docker/scripts/logs/README.txt


### PR DESCRIPTION
The gitattributes change ensures line endings remain LF when the repo is cloned on windows. This made it easy to run the script directly from WSL. I can also configure git to do this but doing it at the repo level ensures everyone clones the repo correctly.

I also updated gitignore to exclude logs.